### PR TITLE
Linear CLmax by wing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ todo.md
 *.egg-info
 *.ini
 dist
+validacao*

--- a/lltdrek/models/simulation.py
+++ b/lltdrek/models/simulation.py
@@ -58,9 +58,7 @@ class Simulation:
                     wing_pool=self.wing_pool,
                     matrix_dim=self.matrix_dim
                     )
-                G_linear_solution = G # debugging purposes
                 G_dict = self.wing_pool.update_solution(G_solution=G)
-                a=1
 
             total_velocity_dict = self.wing_pool.calculate_total_velocity(
                 aoa_idx=idx,
@@ -87,9 +85,10 @@ class Simulation:
                     self.matrix_dim,
                     self.linear_check
                 )
-
                 if iteration > self.max_iter:
-                    G_solution_list.append(np.nan)
+                    G_solution = np.ones(self.matrix_dim) * np.nan
+                    G_dict = self.wing_pool.update_solution(G_solution=G_solution)
+                    G_solution_list.append(G_dict)
                     if "last_successful_solution" in locals():
                         G_dict = last_successful_solution_dict
                     else:
@@ -112,6 +111,7 @@ class Simulation:
                         G_dict=G_dict
                         )
                     aoa_eff_dict = self.wing_pool.calculate_aoa_eff(total_velocity_dict)
+                    # print(f"aoa_eff_dict: {aoa_eff_dict['asa'] * 180 / np.pi}")
                     iteration += 1
 
         return G_solution_list

--- a/lltdrek/simulation/main_equations.py
+++ b/lltdrek/simulation/main_equations.py
@@ -64,6 +64,7 @@ def calculate_main_equation(
         aoa_eff_distr = aoa_eff_dict[wing.surface_name]
         G_list = G_dict[wing.surface_name]
         total_velocity_distr = total_velocity_dict[wing.surface_name]
+        # print(f"main, asa: {wing.surface_name}")
         for i, _ in enumerate(wing.collocation_points):
             if linear_check:
                 linear_data = get_linear_data_and_clmax(wing.cp_airfoils[i], wing.cp_reynolds[i], wing.airfoil_data)
@@ -83,6 +84,7 @@ def calculate_main_equation(
                 - Cl_i
             R_array[N_panels+i_glob] = R_array[i_glob]
             i_glob += 1
+        # print(f"Cl_array: {Cl_array}")
     return R_array
 
 
@@ -105,6 +107,7 @@ def calculate_corrector_equation(
     i_glob = 0
     Cl_alpha_array = np.zeros(matrix_dim) # Used for debugging purposes
     for wing_i in wing_pool.complete_wing_pool:
+        # print(f"corrector, asa: {wing_i.surface_name}")
         G_distr = G_dict[wing_i.surface_name]
         total_velocity_distr = total_velocity_dict[wing_i.surface_name]
         aoa_eff_distr = aoa_eff_dict[wing_i.surface_name]
@@ -156,6 +159,7 @@ def calculate_corrector_equation(
                     J_matrix[i_glob][N_panels+j_glob] = coef_ij_m
                     j_glob += 1
             i_glob += 1
+        # print(f"Cl_alpha_array: {Cl_alpha_array}")
 
     delta_G = npla.solve(J_matrix, -R_array)
     return delta_G

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lltdrek"
-version = "0.1.1"
+version = "0.2.0"
 authors = [
   { name="Luis Kuodrek", email="kuodrek@gmail.com" },
 ]


### PR DESCRIPTION
# Overview
- CLmax linear retorna o CLmax por asa
  - Útil para verificar o CLmax de cada asa no caso de um sistema (múltiplas asas, asa + eh, etc)
- Adição de um método que verifica se a solução de uma simulação é válida ou não