### PR TITLE
Add GitHub pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## What does this PR do?
+
+<!-- One or two sentences. What changed and why? -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor
+- [ ] Docs / tooling
+
+## How to test
+
+<!-- Steps to verify the change works. Can be "run make test" for simple changes. -->
+
+## Checklist
+
+- [ ] `make test` passes
+- [ ] `make lint` passes
+- [ ] New public interfaces / design decisions are documented (docstring, `README.md`, or `CLAUDE.md` as appropriate)
+- [ ] No documentation update needed (internal change only)


### PR DESCRIPTION
## What does this PR do?

Adds a default GitHub pull request template to standardize PR descriptions across the project.

## Type of change

- [x] Docs / tooling

## How to test

Open a new PR after merging — GitHub will auto-populate the description with the template.

## Checklist

- [x] `make test` passes
- [x] `make lint` passes
- [x] New public interfaces / design decisions are documented (docstring, `README.md`, or `CLAUDE.md` as appropriate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)